### PR TITLE
Potential fix for code scanning alert no. 15: Client-side cross-site scripting

### DIFF
--- a/fabiplus/admin/templates/logs.html
+++ b/fabiplus/admin/templates/logs.html
@@ -439,8 +439,8 @@ function addLogEntry(logData) {
     const timestamp = new Date(logData.timestamp).toLocaleTimeString();
     entry.innerHTML = `
         <span class="log-timestamp">[${timestamp}]</span>
-        <span class="log-level">${logData.level}</span>
-        <span class="log-logger">${logData.logger}</span>
+        <span class="log-level">${escapeHtml(logData.level)}</span>
+        <span class="log-logger">${escapeHtml(logData.logger)}</span>
         <span class="log-message">${escapeHtml(logData.message)}</span>
     `;
     


### PR DESCRIPTION
Potential fix for [https://github.com/Helevon-Technologies-LTD/fabiplus/security/code-scanning/15](https://github.com/Helevon-Technologies-LTD/fabiplus/security/code-scanning/15)

To fix the DOM-based XSS vulnerability, all user-controlled data interpolated into HTML must be properly escaped before being assigned to `innerHTML`. In this case, `logData.level` and `logData.logger` are inserted directly into the HTML template string without escaping. The best fix is to apply the same `escapeHtml` function (already used for `logData.message`) to these fields as well. This change should be made in the `addLogEntry` function, specifically in the template string assigned to `entry.innerHTML` (lines 440–445). No changes to imports or additional dependencies are required, as the `escapeHtml` function is already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
